### PR TITLE
Fix broken test t/dist.t

### DIFF
--- a/lib/DBIx/Interp.pm
+++ b/lib/DBIx/Interp.pm
@@ -15,7 +15,7 @@ use Sub::Exporter -setup => {
     ],
 };
 
-our $VERSION = '1.22';
+our $VERSION = '1.24';
 
 our @CARP_NOT =
     qw(DBIx::Interp DBIx::Interp::db DBIx::Interp::STX);

--- a/lib/SQL/Interp.pm
+++ b/lib/SQL/Interp.pm
@@ -1,6 +1,6 @@
 package SQL::Interp;
 
-our $VERSION = '1.23';
+our $VERSION = '1.24';
 
 use strict;
 use warnings;


### PR DESCRIPTION
Previous release broke t/dist.t (which checks that both modules are in
sync version-wise). Bump both to v1.24 which should be the next release
version.

No functional changes, tests pass.