### PR TITLE
Add support for passing PostgreSQL ARRAY values

### DIFF
--- a/t/sql_interp.t
+++ b/t/sql_interp.t
@@ -178,6 +178,20 @@ interp_test(['WHERE field in', $v0],
             ['WHERE 1=0'],
             'IN lowercase');  # fails in 0.31
 
+# ARRAY
+interp_test(['SELECT ARRAY', $maybe_array],
+            ['SELECT ARRAY[?, ?]', @$maybe_array],
+            'ARRAY');
+interp_test(['SELECT ARRAY', \$maybe_array],
+            ['SELECT ARRAY[?, ?]', @$maybe_array],
+            'ARRAY ref');
+interp_test(['SELECT ARRAY', \$v0],
+            ['SELECT ARRAY[]'],
+            'ARRAY empty');
+interp_test(['SELECT ARRAY', \$x],
+            ['SELECT ARRAY[?]', $x],
+            'ARRAY scalar');
+
 # SET
 interp_test(['UPDATE mytable SET', $h],
             ["UPDATE mytable SET $hi->{keys}[0]=?, $hi->{keys}[1]=?", @{$hi->{values}}],


### PR DESCRIPTION
Right now there's no way to conveniently pass a Perl array to a PostgreSQL `ARRAY` type. This PR changes that by adding an `ARRAY` context.

To be honest, there are several ways to do this and I'm not entirely sure which one is the best. First of all, the exposed API:

1. The current approach: Add a new `ARRAY` context that mimics the `IN` context.
2. Add support for arrays to `sql_type()`, e.g. `sql_type(\@array, array => 1)`. This needs a new flag, since `sql_interp` already expands arrays given to `sql_type`.
3. Add a new `sql_array()` or `sql_raw_param()` function that works like `sql_type()` but passes the given value without expanding arrays.

And then there are two variations in terms of the SQL to generate and return:

1. The current approach: Generate SQL in the form of `ARRAY[?, ?]` and add individual array elements as bind parameters. This has the advantage that it's pretty generic and should (theoretically) work with other modules than DBD::Pg - provided the database supports that array syntax.
2. (Slightly?) more efficient approach: Generate SQL in the form of `?` (i.e. a single bind parameter) and pass the array as a single bind parameter. DBD::Pg will handle the conversion to a PostgreSQL array. This has the advantage that prepared statements can be reused if the array length varies.

I'm open to feedback to use a different alternative, any of these work fine for me.

This PR is kind-of related to [#39778](https://rt.cpan.org/Public/Bug/Display.html?id=39778), except it doesn't attempt to optimize the `IN` clause and, in fact, doesn't reduce the number of bind parameters in its current form.